### PR TITLE
Handle vtrees

### DIFF
--- a/input/params/defaults.par
+++ b/input/params/defaults.par
@@ -243,7 +243,7 @@ ReionSMParam_c         : 2.0
 ReionSMParam_d         : 2.5
 
 ReionTcool             : 1.0e4  # Kelvin
-ReionNionPhotPerBary   : 6000 # Since the IMF has been updated for the UV luminosity.
+ReionNionPhotPerBary   : 4000 
 
 ReionSfrTimescale          : 0.5
 TsHeatingFilterType        : 1 

--- a/input/params/defaults.par
+++ b/input/params/defaults.par
@@ -46,7 +46,7 @@ ZCrit                      : 0.0001 # Critical metallicity. If Z >= Zcrit -> Pop
 #-------------------------------------------------------------------
 
 LXrayGal                   : 3.16e40         # Soft-band (< NuXraySoftCut keV) X-ray luminosity for galaxy based sources (HMXB)
-LXrayGalIII                   : 3.16e40         # Same as above for PopIII
+LXrayGalIII                : 3.16e40         # Same as above for PopIII
 
 NuXrayGalThreshold         : 500.            # Energy threshold for HMXB X-rays escaping host galaxy (eV)
 SpecIndexXrayGal           : 1.              # Spectral index of galaxy X-ray sources  (nu^-alpha)

--- a/input/params/input.par
+++ b/input/params/input.par
@@ -18,7 +18,7 @@
 
 FileNameGalaxies     : meraxes
 DefaultsFile         : @INPUT_FILE_DIR@/params/defaults.par
-SimParamsFile        : @INPUT_FILE_DIR@/params/simulations/Genesis_L10_N2048_PopIII.par
+SimParamsFile        : @INPUT_FILE_DIR@/params/simulations/Genesis_L210_N4320.par
 OutputSnapshots      : -1
 OutputDir            : output
 PhotometricTablesDir : @INPUT_FILE_DIR@/photometric_tables

--- a/input/params/simulations/Genesis_L210_N4320.par
+++ b/input/params/simulations/Genesis_L210_N4320.par
@@ -27,3 +27,35 @@ NPart: 80621568000
 UnitLength_in_cm         : 3.08568e+24       # WATCH OUT : Mpc/h
 UnitMass_in_g            : 1.989e+43         # WATCH OUT : 10^10Msun/h
 UnitVelocity_in_cm_per_s : 100000            # WATCH OUT : km/s
+
+
+#-------------------------------------------------
+#----- Astrophysical parameters since Balu+22 ----
+#-------------------------------------------------
+
+ReionNionPhotPerBary : 6000
+ReionGridDim : 1024
+
+ReincorporationModel : 2
+ReincorporationEff        : 18000    # gas reincorporation efficiency from ejected component
+
+SfEfficiency              : 0.09966
+SfCriticalSDNorm          : 0.01382
+
+SnModel                   : 2
+SnEjectionEff             : 1.53782     # SN feedback gas reheating efficiency
+SnEjectionScaling         : 1.0
+SnEjectionScaling2        : 3.2
+
+SnReheatRedshiftDep       : 2.0
+SnReheatEff               : 6.97996    # mass loading factor for SN feedback
+SnReheatScaling           : 1.0
+SnReheatScaling2          : 3.2
+SnReheatNorm              : 60.0
+SnReheatLimit             : 10000.0    # maximum allowed mass loading factor for SN feedback
+
+EscapeFracDependency : 5 # 0->none, 1->redshift, 2->stellar mass, 3->sfr, 4->cold gas surface density, 5->mvir, 6->ssfr
+EscapeFracNorm : 0.15
+EscapeFracPropScaling : 0.00
+EscapeFracRedshiftScaling : 0
+EscapeFracBHNorm : 0

--- a/input/params/simulations/Genesis_L210_N4320.par
+++ b/input/params/simulations/Genesis_L210_N4320.par
@@ -33,6 +33,13 @@ UnitVelocity_in_cm_per_s : 100000            # WATCH OUT : km/s
 #----- Astrophysical parameters since Balu+22 ----
 #-------------------------------------------------
 
+FlagIgnoreProgIndex        : 1
+Flag_IncludePecVelsFor21cm : 2
+Flag_IncludeSpinTemp       : 1
+Flag_ComputePS             : 1
+Flag_Compute21cmBrightTemp : 1
+Flag_IncludeRecombinations : 1
+
 ReionNionPhotPerBary : 6000
 ReionGridDim : 1024
 
@@ -54,8 +61,7 @@ SnReheatScaling2          : 3.2
 SnReheatNorm              : 60.0
 SnReheatLimit             : 10000.0    # maximum allowed mass loading factor for SN feedback
 
-EscapeFracDependency : 5 # 0->none, 1->redshift, 2->stellar mass, 3->sfr, 4->cold gas surface density, 5->mvir, 6->ssfr
-EscapeFracNorm : 0.15
-EscapeFracPropScaling : 0.00
-EscapeFracRedshiftScaling : 0
-EscapeFracBHNorm : 0
+EscapeFracDependency      : 1  # 0->none, 1->redshift, 2->stellar mass, 3->sfr, 4->cold gas surface density, 5->mvir, 6->ssfr
+EscapeFracNorm            : 0.14
+EscapeFracRedshiftOffset  : 6.0
+EscapeFracRedshiftScaling : 0.2

--- a/input/params/simulations/Genesis_L210_N4320.par
+++ b/input/params/simulations/Genesis_L210_N4320.par
@@ -2,9 +2,9 @@
 #----- Simulation input files  ------------
 #------------------------------------------
 SimName           : Genesis L210_N4320
-SimulationDir     : /fred/oz113/balu/files_for_meraxes/L210_N4320/un_augmented_trees
+SimulationDir     : /fred/oz113/yqin/dragons/input_trees/Genesis_L210_N4320
 CatalogFilePrefix : VELOCIraptor.walkabletree.forestID.hdf5.0
-TreesID           : 0  # 0 -> VELOCIraptor; 1 -> gbpTrees
+TreesID           : 0  # 0 -> VELOCIraptor; 1 -> gbpTrees, 2 -> VELOCIraptor augmented
 BoxSize           : 210.0
 VolumeFactor      : 1.0
 

--- a/src/core/galaxies.c
+++ b/src/core/galaxies.c
@@ -257,6 +257,7 @@ void connect_galaxy_and_halo(galaxy_t* gal, halo_t* halo, int* merger_counter)
         break;
 
       case VELOCIRAPTOR_TREES:
+      case VELOCIRAPTOR_TREES_AUG:
         // For VELOCIraptor we have some guidance in the form of the progenitor indices.
 
         if (check_for_flag(TREE_CASE_NO_PROGENITORS, halo->TreeFlags)) {

--- a/src/core/read_halos-gbptrees.c
+++ b/src/core/read_halos-gbptrees.c
@@ -485,9 +485,7 @@ void read_trees__gbptrees(int snapshot,
         cur_halo->Vel[2] = cur_cat_halo->velocity_COM[2];
         cur_halo->Rvir = cur_cat_halo->R_vir;
         cur_halo->Vmax = cur_cat_halo->V_max;
-        cur_halo->AngMom[0] = cur_cat_halo->ang_mom[0];
-        cur_halo->AngMom[1] = cur_cat_halo->ang_mom[1];
-        cur_halo->AngMom[2] = cur_cat_halo->ang_mom[2];
+        cur_halo->AngMom = sqrt(cur_cat_halo->ang_mom[0] * cur_cat_halo->ang_mom[0] + cur_cat_halo->ang_mom[1] * cur_cat_halo->ang_mom[1] + cur_cat_halo->ang_mom[2]* cur_cat_halo->ang_mom[2]);
         cur_halo->Galaxy = NULL;
         cur_halo->Mvir = cur_cat_halo->M_vir;
 

--- a/src/core/read_halos-velociraptor.c
+++ b/src/core/read_halos-velociraptor.c
@@ -17,7 +17,17 @@ trees_info_t read_trees_info__velociraptor(const int snapshot)
   if (run_globals.mpi_rank == 0) {
     // TODO: This could maybe only ever be done once and stored in run_globals.
     char fname[STRLEN + 34];
-    sprintf(fname, "%s/trees/meraxes_augmented_stats.h5", run_globals.params.SimulationDir);
+	switch (run_globals.params.TreesID) {
+	  case VELOCIRAPTOR_TREES:
+		sprintf(fname, "%s/trees/meraxes_augmented_stats.h5", run_globals.params.SimulationDir);
+		break;
+	  case VELOCIRAPTOR_TREES_AUG:
+		sprintf(fname, "%s/augmented_trees/meraxes_augmented_stats.h5", run_globals.params.SimulationDir);
+		break;
+	  default:
+		mlog_error("Unrecognised input trees identifier (TreesID).");
+		break;
+	}
 
     hid_t fd = H5Fopen(fname, H5F_ACC_RDONLY, H5P_DEFAULT);
     if (fd < 0) {
@@ -374,9 +384,284 @@ void read_trees__velociraptor(int snapshot,
         halo->Vvir = -1;
         convert_input_virial_props(&halo->Mvir, &halo->Rvir, &halo->Vvir, NULL, -1, snapshot, false);
 
-        halo->AngMom[0] = (float)(tree_entry.Lx / tree_entry.Mass_tot);
-        halo->AngMom[1] = (float)(tree_entry.Ly / tree_entry.Mass_tot);
-        halo->AngMom[2] = (float)(tree_entry.Lz / tree_entry.Mass_tot);
+        halo->AngMom = (float)(sqrt(tree_entry.Lx * tree_entry.Lx + tree_entry.Ly * tree_entry.Ly + tree_entry.Lz * tree_entry.Lz) / tree_entry.Mass_tot);
+        halo->Galaxy = NULL;
+
+        (*n_halos)++;
+      }
+    }
+
+    n_read += n_to_read;
+  }
+
+  free(tree_entries);
+
+  if (run_globals.mpi_rank == 0) {
+    free(property_buffer);
+    H5Gclose(snap_group);
+    H5Fclose(fd);
+  }
+
+  mlog("...done", MLOG_CLOSE);
+}
+
+void read_trees__velociraptor_aug(int snapshot,
+                              halo_t* halos,
+                              int* n_halos,
+                              fof_group_t* fof_groups,
+                              int* n_fof_groups,
+                              int* index_lookup)
+{
+  // TODO: For the moment, I'll forgo chunking the read.  This will need to
+  // be implemented in future though, as we ramp up the size of the trees
+
+  //! Tree entry struct
+  typedef struct tree_entry_t
+  {
+    long ForestID;
+    long Head;
+    long hostHaloID;
+    float Mass_200crit;
+    float Mass_tot;
+    float R_200crit;
+    float Vmax;
+    float Xc;
+    float Yc;
+    float Zc;
+    float VXc;
+    float VYc;
+    float VZc;
+    float AngMom;
+    unsigned long ID;
+    unsigned long npart;
+  } tree_entry_t;
+
+  // simulations...
+
+  mlog("Reading augmented velociraptor trees for snapshot %d...", MLOG_OPEN, snapshot);
+
+  int n_tree_entries = 0;
+  hid_t fd = -1;
+  hid_t snap_group = -1;
+  void* property_buffer = NULL;
+  double mass_unit_to_internal = 1.0;
+  double scale_factor = -999.;
+
+  *n_halos = 0;
+  *n_fof_groups = 0;
+
+  int buffer_size = 10000; // NOTE: Arbitrary. Should be a multiple of the chunk size of arrays in file ideally?
+  tree_entry_t* tree_entries = malloc(sizeof(tree_entry_t) * buffer_size);
+
+  if (run_globals.mpi_rank == 0) {
+    char fname[STRLEN * 2 + 8];
+    sprintf(fname, "%s/augmented_trees/%s", run_globals.params.SimulationDir, run_globals.params.CatalogFilePrefix);
+
+    fd = H5Fopen(fname, H5F_ACC_RDONLY, H5P_DEFAULT);
+    if (fd < 0) {
+      mlog("Failed to open file %s", MLOG_MESG, fname);
+      ABORT(EXIT_FAILURE);
+    }
+
+    char snap_group_name[9];
+    sprintf(snap_group_name, "Snap_%03d", snapshot);
+    snap_group = H5Gopen(fd, snap_group_name, H5P_DEFAULT);
+
+    H5LTget_attribute_int(fd, snap_group_name, "NHalos", &n_tree_entries);
+
+    property_buffer = malloc(buffer_size * sizeof(long));
+
+    // check the units
+    H5LTget_attribute_double(fd, "Header/Units", "Mass_unit_to_solarmass", &mass_unit_to_internal);
+    mass_unit_to_internal /= 1.0e10;
+    H5LTget_attribute_double(fd, snap_group_name, "scalefactor", &scale_factor);
+  }
+
+  MPI_Bcast(&n_tree_entries, 1, MPI_INT, 0, run_globals.mpi_comm);
+  MPI_Bcast(&mass_unit_to_internal, 1, MPI_DOUBLE, 0, run_globals.mpi_comm);
+
+  int n_read = 0;
+  int n_to_read = buffer_size > n_tree_entries ? n_tree_entries : buffer_size;
+  while (n_read < n_tree_entries) {
+    int n_remaining = n_tree_entries - n_read;
+    if (n_remaining < n_to_read) {
+      n_to_read = n_remaining;
+    }
+
+    if (run_globals.mpi_rank == 0) {
+
+      // select a hyperslab in the filespace
+      hid_t fspace_id = H5Screate_simple(1, (hsize_t[1]){ n_tree_entries }, NULL);
+      H5Sselect_hyperslab(fspace_id, H5S_SELECT_SET, (hsize_t[1]){ n_read }, NULL, (hsize_t[1]){ n_to_read }, NULL);
+      hid_t memspace_id = H5Screate_simple(1, (hsize_t[1]){ n_to_read }, NULL);
+
+#define READ_TREE_ENTRY_PROP(name, type, h5type)                                                                       \
+  {                                                                                                                    \
+    hid_t dset_id = H5Dopen(snap_group, #name, H5P_DEFAULT);                                                           \
+    herr_t status = H5Dread(dset_id, h5type, memspace_id, fspace_id, H5P_DEFAULT, property_buffer);                    \
+    assert(status >= 0);                                                                                               \
+    H5Dclose(dset_id);                                                                                                 \
+    for (int ii = 0; ii < n_to_read; ii++) {                                                                           \
+      tree_entries[ii].name = ((type*)property_buffer)[ii];                                                            \
+    }                                                                                                                  \
+  }
+
+      // TODO(trees): Read tail.  If head<->tail then first progenitor line, else it's a merger.  We should populate the
+      // new halo and then do a standard merger prescription.
+
+      READ_TREE_ENTRY_PROP(ForestID, long, H5T_NATIVE_LONG);
+      READ_TREE_ENTRY_PROP(Head, long, H5T_NATIVE_LONG);
+      READ_TREE_ENTRY_PROP(hostHaloID, long, H5T_NATIVE_LONG);
+      READ_TREE_ENTRY_PROP(Mass_200crit, float, H5T_NATIVE_FLOAT);
+      READ_TREE_ENTRY_PROP(Mass_tot, float, H5T_NATIVE_FLOAT);
+      READ_TREE_ENTRY_PROP(R_200crit, float, H5T_NATIVE_FLOAT);
+      READ_TREE_ENTRY_PROP(Vmax, float, H5T_NATIVE_FLOAT);
+      READ_TREE_ENTRY_PROP(Xc, float, H5T_NATIVE_FLOAT);
+      READ_TREE_ENTRY_PROP(Yc, float, H5T_NATIVE_FLOAT);
+      READ_TREE_ENTRY_PROP(Zc, float, H5T_NATIVE_FLOAT);
+      READ_TREE_ENTRY_PROP(VXc, float, H5T_NATIVE_FLOAT);
+      READ_TREE_ENTRY_PROP(VYc, float, H5T_NATIVE_FLOAT);
+      READ_TREE_ENTRY_PROP(VZc, float, H5T_NATIVE_FLOAT);
+      READ_TREE_ENTRY_PROP(AngMom, float, H5T_NATIVE_FLOAT);
+      READ_TREE_ENTRY_PROP(ID, unsigned long, H5T_NATIVE_ULONG);
+      READ_TREE_ENTRY_PROP(npart, unsigned long, H5T_NATIVE_ULONG);
+
+      H5Sclose(memspace_id);
+      H5Sclose(fspace_id);
+
+      double hubble_h = run_globals.params.Hubble_h;
+      for (int ii = 0; ii < n_to_read; ii++) {
+        tree_entries[ii].Xc *= hubble_h / scale_factor;
+        tree_entries[ii].Yc *= hubble_h / scale_factor;
+        tree_entries[ii].Zc *= hubble_h / scale_factor;
+        tree_entries[ii].VXc /= scale_factor;
+        tree_entries[ii].VYc /= scale_factor;
+        tree_entries[ii].VZc /= scale_factor;
+        tree_entries[ii].AngMom *= hubble_h * hubble_h * mass_unit_to_internal;
+
+        // TEMPORARY HACK
+        double box_size = run_globals.params.BoxSize;
+        if (tree_entries[ii].Xc < 0.0)
+          tree_entries[ii].Xc = 0.0;
+        if (tree_entries[ii].Xc > box_size)
+          tree_entries[ii].Xc = box_size;
+        if (tree_entries[ii].Yc < 0.0)
+          tree_entries[ii].Yc = 0.0;
+        if (tree_entries[ii].Yc > box_size)
+          tree_entries[ii].Yc = box_size;
+        if (tree_entries[ii].Zc < 0.0)
+          tree_entries[ii].Zc = 0.0;
+        if (tree_entries[ii].Zc > box_size)
+          tree_entries[ii].Zc = box_size;
+
+#ifdef DEBUG
+        assert((tree_entries[ii].Xc <= box_size) && (tree_entries[ii].Xc >= 0.0));
+        assert((tree_entries[ii].Yc <= box_size) && (tree_entries[ii].Yc >= 0.0));
+        assert((tree_entries[ii].Zc <= box_size) && (tree_entries[ii].Zc >= 0.0));
+#endif
+      }
+    }
+
+    size_t _nbytes = sizeof(tree_entry_t) * n_to_read;
+    MPI_Bcast(tree_entries, (int)_nbytes, MPI_BYTE, 0, run_globals.mpi_comm);
+
+    for (int ii = 0; ii < n_to_read; ++ii) {
+      bool keep_this_halo = true;
+
+      if ((run_globals.RequestedForestId != NULL) && (bsearch(&(tree_entries[ii].ForestID),
+                                                              run_globals.RequestedForestId,
+                                                              (size_t)run_globals.NRequestedForests,
+                                                              sizeof(long),
+                                                              compare_longs)) == NULL)
+        keep_this_halo = false;
+
+      if (keep_this_halo) {
+        tree_entry_t tree_entry = tree_entries[ii];
+        halo_t* halo = &(halos[*n_halos]);
+
+        halo->ID = tree_entry.ID;
+        halo->DescIndex = id_to_ind(tree_entry.Head);
+
+        if (run_globals.params.FlagIgnoreProgIndex)
+          halo->ProgIndex = -1;
+        else
+          halo->ProgIndex = tree_entry.ID-1;
+
+        halo->NextHaloInFOFGroup = NULL;
+        halo->Type = tree_entry.hostHaloID == -1 ? 0 : 1;
+        halo->SnapOffset = id_to_snap(tree_entry.Head) - snapshot;
+        halo->TreeFlags = TREE_CASE_NO_PROGENITORS;
+
+        // Here we have a cyclic pointer, indicating that this halo's life ends here
+        if ((unsigned long)tree_entry.Head == tree_entry.ID)
+        //if (tree_entry.Head == halo->ID)
+          halo->DescIndex = -1;
+
+        if (index_lookup)
+          index_lookup[*n_halos] = ii + n_read;
+
+        // TODO: What masses and radii should I use for centrals (inclusive vs. exclusive etc.)?
+        if (halo->Type == 0) {
+          fof_group_t* fof_group = &fof_groups[*n_fof_groups];
+
+          if (tree_entry.Mass_200crit <= 0) {
+            // This "halo" is not above the virial threshold!  Use
+            // proxy masses, but flag this fact so we know not to do
+            // any or allow any hot halo to exist.
+            halo->TreeFlags |= TREE_CASE_BELOW_VIRIAL_THRESHOLD;
+            //fof_group->Mvir = tree_entry.Mass_FOF;
+            fof_group->Mvir = (double)tree_entry.Mass_tot * run_globals.params.Hubble_h * mass_unit_to_internal;
+            fof_group->Rvir = -1;
+          } else {
+              fof_group->Mvir = (double)tree_entry.Mass_200crit * run_globals.params.Hubble_h * mass_unit_to_internal;
+              fof_group->Rvir = (double)tree_entry.R_200crit * run_globals.params.Hubble_h;
+          }
+          fof_group->Vvir = -1;
+          fof_group->FOFMvirModifier = 1.0;
+          
+
+          convert_input_virial_props(
+            &fof_group->Mvir, &fof_group->Rvir, &fof_group->Vvir, &fof_group->FOFMvirModifier, -1, snapshot, true);
+
+          halo->FOFGroup = &(fof_groups[*n_fof_groups]);
+          fof_groups[(*n_fof_groups)++].FirstHalo = halo;
+        } else {
+          // We can take advantage of the fact that host halos always
+          // seem to appear before their subhalos (checked below) in the
+          // trees to immediately connect FOF group members.
+          int host_index = id_to_ind(tree_entry.hostHaloID);
+
+          if (index_lookup)
+            host_index = find_original_index(host_index, index_lookup, *n_halos);
+
+          assert(host_index > -1);
+          assert(host_index < *n_halos);
+
+          halo_t* prev_halo = &halos[host_index];
+          halo->FOFGroup = prev_halo->FOFGroup;
+
+          while (prev_halo->NextHaloInFOFGroup != NULL)
+            prev_halo = prev_halo->NextHaloInFOFGroup;
+
+          prev_halo->NextHaloInFOFGroup = halo;
+        }
+
+        halo->Len = (int)tree_entry.npart;
+        halo->Pos[0] = tree_entry.Xc;
+        halo->Pos[1] = tree_entry.Yc;
+        halo->Pos[2] = tree_entry.Zc;
+        halo->Vel[0] = tree_entry.VXc;
+        halo->Vel[1] = tree_entry.VYc;
+        halo->Vel[2] = tree_entry.VZc;
+        halo->Vmax = tree_entry.Vmax;
+
+        // TODO: What masses and radii should I use for satellites (inclusive vs. exclusive etc.)?
+        halo->Mvir = (double)tree_entry.Mass_tot * run_globals.params.Hubble_h * mass_unit_to_internal;
+        halo->Rvir = -1;
+        halo->Vvir = -1;
+        convert_input_virial_props(&halo->Mvir, &halo->Rvir, &halo->Vvir, NULL, -1, snapshot, false);
+        
+        halo->AngMom = tree_entry.AngMom;  // the augmented trees store the absolute AngMom already
 
         halo->Galaxy = NULL;
 

--- a/src/core/read_halos.c
+++ b/src/core/read_halos.c
@@ -135,6 +135,9 @@ static void select_forests()
       case VELOCIRAPTOR_TREES:
         sprintf(fname, "%s/trees/meraxes_augmented_stats.h5", run_globals.params.SimulationDir);
         break;
+      case VELOCIRAPTOR_TREES_AUG:
+        sprintf(fname, "%s/augmented_trees/meraxes_augmented_stats.h5", run_globals.params.SimulationDir);
+        break;
       case GBPTREES_TREES:
         sprintf(fname, "%s/trees/forests_info.hdf5", run_globals.params.SimulationDir);
         break;
@@ -155,6 +158,7 @@ static void select_forests()
         H5LTget_attribute_int(fd, "info", "n_forests", &n_forests);
         break;
       case VELOCIRAPTOR_TREES:
+      case VELOCIRAPTOR_TREES_AUG:
         H5LTget_attribute_int(fd, "forests", "n_forests", &n_forests);
         break;
       default:
@@ -193,6 +197,7 @@ static void select_forests()
           H5LTread_dataset_int(fd, dset_name, final_counts);
           break;
         case VELOCIRAPTOR_TREES:
+        case VELOCIRAPTOR_TREES_AUG:
           H5LTread_dataset_long(fd, "forests/forest_ids", forest_ids);
           H5LTread_dataset_int(fd, "forests/max_contemporaneous_halos", max_contemp_halo);
           H5LTread_dataset_int(fd, "forests/max_contemporaneous_fof_groups", max_contemp_fof);
@@ -287,6 +292,7 @@ static void select_forests()
           sprintf(dset_name, "snapshots/snap_%03d", snap);
           break;
         case VELOCIRAPTOR_TREES:
+        case VELOCIRAPTOR_TREES_AUG:
           sprintf(dset_name, "snapshots/Snap%03d", snap);
           break;
         default:
@@ -428,6 +434,7 @@ trees_info_t read_halos(const int snapshot,
   trees_info_t trees_info = { 0 };
   switch (run_globals.params.TreesID) {
     case VELOCIRAPTOR_TREES:
+    case VELOCIRAPTOR_TREES_AUG:
       trees_info = read_trees_info__velociraptor(snapshot);
       break;
     case GBPTREES_TREES:
@@ -482,6 +489,10 @@ trees_info_t read_halos(const int snapshot,
   switch (run_globals.params.TreesID) {
     case VELOCIRAPTOR_TREES:
       read_trees__velociraptor(snapshot, *halos, &n_halos, *fof_groups, &n_fof_groups, *index_lookup);
+      break;
+
+    case VELOCIRAPTOR_TREES_AUG:
+      read_trees__velociraptor_aug(snapshot, *halos, &n_halos, *fof_groups, &n_fof_groups, *index_lookup);
       break;
 
     case GBPTREES_TREES: {

--- a/src/core/read_halos.h
+++ b/src/core/read_halos.h
@@ -32,6 +32,13 @@ extern "C"
                                 fof_group_t* fof_groups,
                                 int* n_fof_groups,
                                 int* index_lookup);
+
+  void read_trees__velociraptor_aug(int snapshot,
+                                halo_t* halos,
+                                int* n_halos,
+                                fof_group_t* fof_groups,
+                                int* n_fof_groups,
+                                int* index_lookup);
   trees_info_t read_trees_info__velociraptor(const int snapshot);
 
 #ifdef __cplusplus

--- a/src/core/virial_properties.c
+++ b/src/core/virial_properties.c
@@ -111,9 +111,7 @@ double calculate_Vvir(double Mvir, double Rvir)
 
 double calculate_spin_param(halo_t* halo)
 {
-  double angmom_mag =
-    sqrt(halo->AngMom[0] * halo->AngMom[0] + halo->AngMom[1] * halo->AngMom[1] + halo->AngMom[2] * halo->AngMom[2]);
-  return angmom_mag / (1.414213562 * halo->Vvir * halo->Rvir);
+  return halo->AngMom / (1.414213562 * halo->Vvir * halo->Rvir);
 }
 
 double Vvir_to_Tvir(double Vvir, int halo_type)

--- a/src/meraxes.h
+++ b/src/meraxes.h
@@ -203,7 +203,8 @@ typedef struct physics_params_t
 enum tree_ids
 {
   VELOCIRAPTOR_TREES,
-  GBPTREES_TREES
+  GBPTREES_TREES,
+  VELOCIRAPTOR_TREES_AUG
 };
 
 //! Run params
@@ -654,7 +655,7 @@ typedef struct halo_t
 
   float Pos[3];    //!< Most bound particle position [Mpc/h]
   float Vel[3];    //!< Centre of mass velocity [Mpc/h]
-  float AngMom[3]; //!< Specific angular momentum vector [Mpc/h *km/s]
+  float AngMom; //!< Specific angular momentum length [Mpc/h *km/s]
 
   double Mvir; //!< virial mass [M_sol/h]
   double Rvir; //!< Virial radius [Mpc/h]


### PR DESCRIPTION
@EMventura 

I changed ReionNionPhotPerBary in default.par back to 4000 as this is what we have been using for most models. I believe the 6000 value is for the new IMF introduced in the popIII project? Perhaps, set this in params/simulations/Genesis_L10_N2048_PopIII.par instead. Also, I think most of the new popIII parameters are missing in this new params setup and need to be introduced in
params/simulations/Genesis_L10_N2048_PopIII.par