### PR TITLE
using the right SFR in compute Ts

### DIFF
--- a/src/core/XRayHeatingFunctions.c
+++ b/src/core/XRayHeatingFunctions.c
@@ -1296,6 +1296,7 @@ void evolveInt(float zp,
         zpp = (zpp_edge[zpp_ct] + zpp_edge[zpp_ct - 1]) * 0.5;
         dzpp = zpp_edge[zpp_ct - 1] - zpp_edge[zpp_ct];
       }
+	  dt_dzpp = dtdz(zpp);
 
       // Use this when using the SFR provided by Meraxes
       // Units should be M_solar/s. Factor of (dt_dzp * dzpp) converts from per s to per z'

--- a/src/core/read_params.c
+++ b/src/core/read_params.c
@@ -14,13 +14,17 @@ static void check_problem_params(run_params_t* run_params)
     mlog("*** YOU HAVE PROVIDED A REQUESTED FORESTID FILE. THIS FEATURE HAS NOT BE WELL TESTED. YMMV! ***", MLOG_MESG);
   }
 
-#ifdef USE_CUDA
   if (run_params->Flag_IncludeSpinTemp != 0) {
+#ifdef USE_CUDA
     mlog_error(
       "Spin temperature features are not currently available in the GPU version of find_HII_bubbles!  Exiting...");
     ABORT(EXIT_FAILURE);
-  }
 #endif
+    if (run_globals.params.FlagMCMC != 0){
+      mlog_error("Currently we have to store input sfr grids for all snapshots, so cannot MCMC :(");
+      ABORT(EXIT_FAILURE);
+    }
+  }
 }
 
 static void store_params(entry_t entry[123],

--- a/src/core/reionization.h
+++ b/src/core/reionization.h
@@ -65,7 +65,8 @@ extern "C"
   void assign_Mvir_crit_to_galaxies(int ngals_in_slabs, int flag_feed);
   void construct_baryon_grids(int snapshot, int ngals);
   void gen_grids_fname(const int snapshot, char* name, const bool relative);
-  void save_reion_input_grids(int snapshot);
+  void save_reion_input_grids(int snapshot, int sfr_only);
+  void load_reion_sfr_grids(int snapshot, float weight, const int new_load);
   void save_reion_output_grids(int snapshot);
   bool check_if_reionization_ongoing(int snapshot);
   void filter(fftwf_complex* box, int local_ix_start, int slab_nx, int grid_dim, float R, int filter_type);


### PR DESCRIPTION
first attempt to fix the bug when computing Ts. We should be using SFR at higher redshifts

This is a thing needs to be taken care of carefully -- zpp list might over lap with the sampled redshifts... \

running tests on ozstar