### PR TITLE
Fix read halos

### DIFF
--- a/input/params/simulations/Genesis_L10_N2048.par
+++ b/input/params/simulations/Genesis_L10_N2048.par
@@ -22,3 +22,7 @@ Sigma8: 0.815
 PartMass: 9.935e-7
 wLambda: -1.0
 NPart: 8589934592 
+
+UnitLength_in_cm         : 3.08568e+24       # WATCH OUT : Mpc/h
+UnitMass_in_g            : 1.989e+43         # WATCH OUT : 10^10Msun/h
+UnitVelocity_in_cm_per_s : 100000            # WATCH OUT : km/s

--- a/src/core/init.c
+++ b/src/core/init.c
@@ -292,7 +292,7 @@ void init_meraxes()
   set_ReionEfficiency();
   set_quasar_fobs();
 
-  if (run_globals.params.Flag_ComputePS){
+  if (run_globals.params.Flag_IncludeSpinTemp){
     run_globals.NstoreSnapshots_SFR = set_sfr_history();
     mlog("Storing %d snapshots of SFR histories for Ts.", MLOG_MESG, run_globals.NstoreSnapshots_SFR);
   }

--- a/src/core/read_halos-velociraptor.c
+++ b/src/core/read_halos-velociraptor.c
@@ -248,8 +248,9 @@ void read_trees__velociraptor(int snapshot,
         tree_entries[ii].VXc /= scale_factor;
         tree_entries[ii].VYc /= scale_factor;
         tree_entries[ii].VZc /= scale_factor;
-        tree_entries[ii].AngMom *= hubble_h * mass_unit_to_internal;
-        // NOTE THAT FOR AngMom THERE IS ONLY ONE hubble_h (this is because Lx is h**2 and Mtot is h 
+        tree_entries[ii].AngMom *= hubble_h 
+        // NOTE THAT FOR AngMom THERE IS ONLY ONE hubble_h and no mass_unit_to_internal 
+        // this is because Lx is h**2 * mass_unit_to_internal and Mtot is h * mass_unit_to_internal 
         
         // TEMPORARY HACK: Why is this temporary? Can I remove this comment?
         double box_size = run_globals.params.BoxSize;
@@ -325,17 +326,17 @@ void read_trees__velociraptor(int snapshot,
           // This check is to ensure sensible values of mass_200crit and avoid having 
           // very weird halos
           
-          if ((tree_entry.Mass_200crit < 5 * tree_entry.Mass_tot)) {
+          /*if ((tree_entry.Mass_200crit < 5 * tree_entry.Mass_tot)) {
               fof_group->Mvir = tree_entry.Mass_200crit;
               fof_group->Rvir = tree_entry.R_200crit;
-          }
-          else {
+          }*/
+          //else {
             // BELOW_VIRIAL_THRESHOLD merger halo swammping
-            if (tree_entry.Mass_200crit <= 0)
-               halo->TreeFlags |= TREE_CASE_BELOW_VIRIAL_THRESHOLD;
+          if (tree_entry.Mass_200crit <= 0)
+            halo->TreeFlags |= TREE_CASE_BELOW_VIRIAL_THRESHOLD;
             fof_group->Mvir = tree_entry.Mass_tot;  
             fof_group->Rvir = -1;
-          }
+          //}
           
           fof_group->Vvir = -1;
           fof_group->FOFMvirModifier = 1.0;

--- a/src/core/read_halos-velociraptor.c
+++ b/src/core/read_halos-velociraptor.c
@@ -248,7 +248,7 @@ void read_trees__velociraptor(int snapshot,
         tree_entries[ii].VXc /= scale_factor;
         tree_entries[ii].VYc /= scale_factor;
         tree_entries[ii].VZc /= scale_factor;
-        tree_entries[ii].AngMom *= hubble_h 
+        tree_entries[ii].AngMom *= hubble_h; 
         // NOTE THAT FOR AngMom THERE IS ONLY ONE hubble_h and no mass_unit_to_internal 
         // this is because Lx is h**2 * mass_unit_to_internal and Mtot is h * mass_unit_to_internal 
         
@@ -324,7 +324,7 @@ void read_trees__velociraptor(int snapshot,
           fof_group_t* fof_group = &fof_groups[*n_fof_groups];
           
           // This check is to ensure sensible values of mass_200crit and avoid having 
-          // very weird halos
+          // very weird halos. Put this check back if you feel that the N-body is weird.
           
           /*if ((tree_entry.Mass_200crit < 5 * tree_entry.Mass_tot)) {
               fof_group->Mvir = tree_entry.Mass_200crit;

--- a/src/core/read_halos-velociraptor.c
+++ b/src/core/read_halos-velociraptor.c
@@ -109,7 +109,7 @@ void read_trees__velociraptor(int snapshot,
   typedef struct tree_entry_t
   {
     long ForestID;
-    long Head; // Unsigned long or long? Wouldn't be better to use unsigned long?
+    long Head;
     long Tail; // Keep it for now, maybe you can remove it later on
     long hostHaloID;
     float Mass_200crit;
@@ -124,7 +124,7 @@ void read_trees__velociraptor(int snapshot,
     float VYc;
     float VZc;
     float AngMom;
-    unsigned long ID; // Unsigned long or long?
+    unsigned long ID; 
     unsigned long npart;
   } tree_entry_t;
 
@@ -208,7 +208,7 @@ void read_trees__velociraptor(int snapshot,
       READ_TREE_ENTRY_PROP(Mass_FOF, float, H5T_NATIVE_FLOAT);
       READ_TREE_ENTRY_PROP(Mass_tot, float, H5T_NATIVE_FLOAT);
       READ_TREE_ENTRY_PROP(R_200crit, float, H5T_NATIVE_FLOAT);
-      READ_TREE_ENTRY_PROP(Vmax, float, H5T_NATIVE_FLOAT); // WHAT ARE THE UNITS OF THIS Vmax?? It's never converted with little_h!
+      READ_TREE_ENTRY_PROP(Vmax, float, H5T_NATIVE_FLOAT);
       READ_TREE_ENTRY_PROP(Xc, float, H5T_NATIVE_FLOAT);
       READ_TREE_ENTRY_PROP(Yc, float, H5T_NATIVE_FLOAT);
       READ_TREE_ENTRY_PROP(Zc, float, H5T_NATIVE_FLOAT);
@@ -228,7 +228,6 @@ void read_trees__velociraptor(int snapshot,
         tree_entries[ii].Mass_FOF *= hubble_h * mass_unit_to_internal;
         tree_entries[ii].Mass_tot *= hubble_h * mass_unit_to_internal;
         tree_entries[ii].R_200crit *= hubble_h;
-        //Vmax is never converted! Is this a mistake??
         tree_entries[ii].Xc *= hubble_h / scale_factor;
         tree_entries[ii].Yc *= hubble_h / scale_factor;
         tree_entries[ii].Zc *= hubble_h / scale_factor;
@@ -310,47 +309,6 @@ void read_trees__velociraptor(int snapshot,
         if (halo->Type == 0) {
           fof_group_t* fof_group = &fof_groups[*n_fof_groups];
           
-          // Might need to change one of the conditions below
-          if ((tree_entry.Mass_200crit < tree_entry.Mass_FOF) && (tree_entry.Mass_200crit > tree_entry.Mass_tot)) {
-              fof_group->Mvir = tree_entry.Mass_200crit;
-              fof_group->Rvir = tree_entry.R_200crit;
-          }
-          else {
-              // BELOW_VIRIAL_THRESHOLD merger halo swammping
-              if (tree_entry.Mass_200crit <= 0)
-                 halo->TreeFlags |= TREE_CASE_BELOW_VIRIAL_THRESHOLD;
-              fof_group->Mvir = tree_entry.Mass_FOF;
-              fof_group->Rvir = -1;
-          }
-
-          /*if (tree_entry.Mass_200crit <= 0) {
-            // This "halo" is not above the virial threshold!  Use
-            // proxy masses, but flag this fact so we know not to do
-            // any or allow any hot halo to exist.
-            halo->TreeFlags |= TREE_CASE_BELOW_VIRIAL_THRESHOLD;
-            fof_group->Mvir = tree_entry.Mass_FOF;
-            fof_group->Rvir = -1;
-            // } else if (tree_entry.Mass_200crit < tree_entry.Mass_tot){
-            // // The central subhalo has a proxy mass larger than the FOF
-            // // group. Entirely possible for non-virialised and relaxed
-            // // halos but doesn't really lead to internal consistency.
-            // // Let's therefore just set the FOF virial mass to be that
-            // // central subhalo proxy mass.
-            // fof_group->Mvir = tree_entry.Mass_FOF;
-            // fof_group->Rvir = -1;
-          } else {
-            if ((tree_entry.Mass_200crit >= tree_entry.Mass_FOF) || (tree_entry.Mass_200crit < tree_entry.Mass_tot)) {
-              // Adding this since we found an issue in the N-body
-              fof_group->Mvir = tree_entry.Mass_FOF;
-              fof_group->Rvir = -1;
-            }
-
-            else {
-              fof_group->Mvir = tree_entry.Mass_200crit;
-              fof_group->Rvir = tree_entry.R_200crit;
-            }
-          }*/
-          
           // Part below still work in progress, need to make sure of few things
           
           if ((tree_entry.Mass_200crit < tree_entry.Mass_FOF) && (tree_entry.Mass_200crit > tree_entry.Mass_tot)) {
@@ -404,7 +362,7 @@ void read_trees__velociraptor(int snapshot,
         halo->Vel[0] = tree_entry.VXc;
         halo->Vel[1] = tree_entry.VYc;
         halo->Vel[2] = tree_entry.VZc;
-        halo->Vmax = tree_entry.Vmax; // Differently from other velocities this was never converted!
+        halo->Vmax = tree_entry.Vmax; 
 
         // TODO: What masses and radii should I use for satellites (inclusive vs. exclusive etc.)?
         halo->Mvir = (double)tree_entry.Mass_tot;
@@ -567,7 +525,6 @@ void read_trees__velociraptor_aug(int snapshot,
         tree_entries[ii].Mass_FOF *= hubble_h * mass_unit_to_internal;
         tree_entries[ii].Mass_tot *= hubble_h * mass_unit_to_internal;
         tree_entries[ii].R_200crit *= hubble_h;
-        //Vmax is never converted! Is this a mistake??
         tree_entries[ii].Xc *= hubble_h / scale_factor;
         tree_entries[ii].Yc *= hubble_h / scale_factor;
         tree_entries[ii].Zc *= hubble_h / scale_factor;
@@ -640,6 +597,21 @@ void read_trees__velociraptor_aug(int snapshot,
         // TODO: What masses and radii should I use for centrals (inclusive vs. exclusive etc.)?
         if (halo->Type == 0) {
           fof_group_t* fof_group = &fof_groups[*n_fof_groups];
+          
+          // Part below still work in progress!
+          
+          // Might need to change one of the conditions below
+          if ((tree_entry.Mass_200crit < tree_entry.Mass_FOF) && (tree_entry.Mass_200crit > tree_entry.Mass_tot)) {
+              fof_group->Mvir = tree_entry.Mass_200crit;
+              fof_group->Rvir = tree_entry.R_200crit;
+          }
+          else {
+              // BELOW_VIRIAL_THRESHOLD merger halo swammping
+              if (tree_entry.Mass_200crit <= 0)
+                 halo->TreeFlags |= TREE_CASE_BELOW_VIRIAL_THRESHOLD;
+              fof_group->Mvir = tree_entry.Mass_FOF;
+              fof_group->Rvir = -1;
+          }
 
           if (tree_entry.Mass_200crit <= 0) {
             // This "halo" is not above the virial threshold!  Use
@@ -690,7 +662,7 @@ void read_trees__velociraptor_aug(int snapshot,
         halo->Vel[0] = tree_entry.VXc;
         halo->Vel[1] = tree_entry.VYc;
         halo->Vel[2] = tree_entry.VZc;
-        halo->Vmax = tree_entry.Vmax; // Differently from other velocities this was never converted!
+        halo->Vmax = tree_entry.Vmax; 
 
         // TODO: What masses and radii should I use for satellites (inclusive vs. exclusive etc.)?
         halo->Mvir = (double)tree_entry.Mass_tot;

--- a/src/core/read_halos-velociraptor.c
+++ b/src/core/read_halos-velociraptor.c
@@ -311,7 +311,7 @@ void read_trees__velociraptor(int snapshot,
           fof_group_t* fof_group = &fof_groups[*n_fof_groups];
           
           // Might need to change one of the conditions below
-          if (tree_entry.Mass_200crit < tree_entry.Mass_FOF) && (tree_entry.Mass_200crit > tree_entry.Mass_tot) {
+          if ((tree_entry.Mass_200crit < tree_entry.Mass_FOF) && (tree_entry.Mass_200crit > tree_entry.Mass_tot)) {
               fof_group->Mvir = tree_entry.Mass_200crit;
               fof_group->Rvir = tree_entry.R_200crit;
           }

--- a/src/core/read_halos-velociraptor.c
+++ b/src/core/read_halos-velociraptor.c
@@ -545,6 +545,7 @@ void read_trees__velociraptor_aug(int snapshot,
       READ_TREE_ENTRY_PROP(hostHaloID, long, H5T_NATIVE_LONG);
       READ_TREE_ENTRY_PROP(Mass_200crit, float, H5T_NATIVE_FLOAT);
       READ_TREE_ENTRY_PROP(Mass_tot, float, H5T_NATIVE_FLOAT);
+      READ_TREE_ENTRY_PROP(Mass_FOF, float, H5T_NATIVE_FLOAT);
       READ_TREE_ENTRY_PROP(R_200crit, float, H5T_NATIVE_FLOAT);
       READ_TREE_ENTRY_PROP(Vmax, float, H5T_NATIVE_FLOAT);
       READ_TREE_ENTRY_PROP(Xc, float, H5T_NATIVE_FLOAT);

--- a/src/core/read_halos-velociraptor.c
+++ b/src/core/read_halos-velociraptor.c
@@ -332,11 +332,16 @@ void read_trees__velociraptor(int snapshot,
           }*/
           //else {
             // BELOW_VIRIAL_THRESHOLD merger halo swammping
-          if (tree_entry.Mass_200crit <= 0)
+          if (tree_entry.Mass_200crit <= 0) {
             halo->TreeFlags |= TREE_CASE_BELOW_VIRIAL_THRESHOLD;
             fof_group->Mvir = tree_entry.Mass_tot;  
             fof_group->Rvir = -1;
-          //}
+          }
+          
+          else {
+            fof_group->Mvir = (double)tree_entry.Mass_200crit;
+            fof_group->Rvir = (double)tree_entry.R_200crit;
+          }
           
           fof_group->Vvir = -1;
           fof_group->FOFMvirModifier = 1.0;

--- a/src/core/read_halos-velociraptor.c
+++ b/src/core/read_halos-velociraptor.c
@@ -353,7 +353,7 @@ void read_trees__velociraptor(int snapshot,
           
           // Part below still work in progress, need to make sure of few things
           
-          if (tree_entry.Mass_200crit < tree_entry.Mass_FOF) && (tree_entry.Mass_200crit > tree_entry.Mass_tot) {
+          if ((tree_entry.Mass_200crit < tree_entry.Mass_FOF) && (tree_entry.Mass_200crit > tree_entry.Mass_tot)) {
               fof_group->Mvir = tree_entry.Mass_200crit;
               fof_group->Rvir = tree_entry.R_200crit;
           }

--- a/src/core/read_halos.c
+++ b/src/core/read_halos.c
@@ -490,6 +490,7 @@ trees_info_t read_halos(const int snapshot,
     case VELOCIRAPTOR_TREES:
     case VELOCIRAPTOR_TREES_AUG:
       read_trees__velociraptor(snapshot, *halos, &n_halos, *fof_groups, &n_fof_groups, *index_lookup);
+      break;
     case GBPTREES_TREES: {
       int n_halos_kept = 0;
       int n_fof_groups_kept = 0;

--- a/src/core/read_halos.c
+++ b/src/core/read_halos.c
@@ -488,13 +488,8 @@ trees_info_t read_halos(const int snapshot,
   // Now actually read in the trees!
   switch (run_globals.params.TreesID) {
     case VELOCIRAPTOR_TREES:
-      read_trees__velociraptor(snapshot, *halos, &n_halos, *fof_groups, &n_fof_groups, *index_lookup);
-      break;
-
     case VELOCIRAPTOR_TREES_AUG:
-      read_trees__velociraptor_aug(snapshot, *halos, &n_halos, *fof_groups, &n_fof_groups, *index_lookup);
-      break;
-
+      read_trees__velociraptor(snapshot, *halos, &n_halos, *fof_groups, &n_fof_groups, *index_lookup);
     case GBPTREES_TREES: {
       int n_halos_kept = 0;
       int n_fof_groups_kept = 0;

--- a/src/core/read_halos.h
+++ b/src/core/read_halos.h
@@ -33,12 +33,6 @@ extern "C"
                                 int* n_fof_groups,
                                 int* index_lookup);
 
-  void read_trees__velociraptor_aug(int snapshot,
-                                halo_t* halos,
-                                int* n_halos,
-                                fof_group_t* fof_groups,
-                                int* n_fof_groups,
-                                int* index_lookup);
   trees_info_t read_trees_info__velociraptor(const int snapshot);
 
 #ifdef __cplusplus

--- a/src/physics/infall.c
+++ b/src/physics/infall.c
@@ -24,7 +24,7 @@ double gas_infall(fof_group_t* FOFgroup, int snapshot)
   double total_coldgas = 0.0;
   double total_ejectedgas = 0.0;
   double total_blackholemass = 0.0;
-#if USE_MINI_HALOS || USE_2DISK_MODEL
+#if USE_MINI_HALOS 
   double total_remnantmass = 0.0; // This come either from the BHs formed after Pop III stars that fail becoming SN and
                                   // directly collapse or from CCSN. Atm these don't accrete and they don't do anything.
 #endif
@@ -40,7 +40,7 @@ double gas_infall(fof_group_t* FOFgroup, int snapshot)
       total_coldgas += gal->ColdGas;
       total_ejectedgas += gal->EjectedGas;
       total_blackholemass += gal->BlackHoleMass + gal->BlackHoleAccretingColdMass;
-#if USE_MINI_HALOS || USE_2DISK_MODEL
+#if USE_MINI_HALOS 
       total_remnantmass += gal->Remnant_Mass;
 #endif
 
@@ -69,7 +69,7 @@ double gas_infall(fof_group_t* FOFgroup, int snapshot)
   }
 
   total_baryons = total_stellarmass + total_hotgas + total_coldgas + total_ejectedgas + total_blackholemass;
-#if USE_MINI_HALOS || USE_2DISK_MODEL
+#if USE_MINI_HALOS 
   total_baryons += total_remnantmass;
 #endif
 

--- a/src/physics/infall.c
+++ b/src/physics/infall.c
@@ -24,7 +24,7 @@ double gas_infall(fof_group_t* FOFgroup, int snapshot)
   double total_coldgas = 0.0;
   double total_ejectedgas = 0.0;
   double total_blackholemass = 0.0;
-#if USE_MINI_HALOS
+#if USE_MINI_HALOS || USE_2DISK_MODEL
   double total_remnantmass = 0.0; // This come either from the BHs formed after Pop III stars that fail becoming SN and
                                   // directly collapse or from CCSN. Atm these don't accrete and they don't do anything.
 #endif
@@ -40,7 +40,7 @@ double gas_infall(fof_group_t* FOFgroup, int snapshot)
       total_coldgas += gal->ColdGas;
       total_ejectedgas += gal->EjectedGas;
       total_blackholemass += gal->BlackHoleMass + gal->BlackHoleAccretingColdMass;
-#if USE_MINI_HALOS
+#if USE_MINI_HALOS || USE_2DISK_MODEL
       total_remnantmass += gal->Remnant_Mass;
 #endif
 
@@ -69,7 +69,7 @@ double gas_infall(fof_group_t* FOFgroup, int snapshot)
   }
 
   total_baryons = total_stellarmass + total_hotgas + total_coldgas + total_ejectedgas + total_blackholemass;
-#if USE_MINI_HALOS
+#if USE_MINI_HALOS || USE_2DISK_MODEL
   total_baryons += total_remnantmass;
 #endif
 


### PR DESCRIPTION
Still work in progress.

At this stage I modified mostly the part of the Unaugmented trees and the main changes are the following:

include AngMom
Get rid of all useless variables (at the moment I kept Tail not knowing if we want to keep it or not)
Converted double to float
Added a few comments on parts that are unclear to me

Correction for M_200crit added but still work in progress. Wrt what we said in the call, we need to be careful that sometimes M_FOF can be = 0 so I added a few extra lines to ensure that when this happens we will take M_tot.

Notice that there might be an issue in the conversion of the angular momentum in the augmented trees @s-balu, can you please take a look at that? (I don't know if you have redone some conversion while changing the trees but since angMom is of the order of L / M and L needs to be corrected by h^2 while M by h^1 that would lead to h^1

Tail still TBD if we will keep it or not, at this stage I am more towards the no but I will wait to chat with Chris before confirming this.
I still need to produce the new augmented trees (where I will need to put back Mass_FOF)

